### PR TITLE
solving undefined libp2pvpn.TunnelIP on Linux

### DIFF
--- a/interface_linux.go
+++ b/interface_linux.go
@@ -53,6 +53,7 @@ func MultiQueue(multiQueue bool) Option {
 // with default values.
 type LinkOptions struct {
 	LocalAddress string
+	RemoteAddress string
 	MTU          int
 }
 
@@ -60,6 +61,13 @@ type LinkOptions struct {
 func LocalAddress(address string) Option {
 	return func(cfg *Config) {
 		cfg.LocalAddress = address
+	}
+}
+
+func TunnelIP(local, remote string) Option {
+	return func(cfg *Config) {
+		cfg.LocalAddress = local
+		cfg.RemoteAddress = remote
 	}
 }
 


### PR DESCRIPTION
Would not compile with "go build" under Ubuntu 22.04 without these changes which I made directly from interface_darwin.go to interface_linux.go.